### PR TITLE
Update adaptive_protection_alert.json

### DIFF
--- a/adaptive_protection_alert.json
+++ b/adaptive_protection_alert.json
@@ -1,7 +1,7 @@
 # gcloud alpha monitoring policies create --policy-from-file=adaptive_protection_alert.json
 
 {
-  "name": "projects/*/alertPolicies/12220852840272900044/conditions/12220852840272899115",
+  "name": "projects/*/alertPolicies/12220852840272900044",
 "displayName": "adaptive protection alert",
   "conditions": [
     {


### PR DESCRIPTION
Fix for the below

> ERROR: (gcloud.alpha.monitoring.policies.create) INVALID_ARGUMENT: Field alert_policy.name had an invalid value of "projects/*/alertPolicies/12220852840272900044/conditions/12220852840272899115": Policy ID '12220852840272900044/conditions/12220852840272899115' is not of the format '[a-zA-Z0-9._~-]{1,255}'.